### PR TITLE
Fix 'No such variable: "b:current_syntax"'

### DIFF
--- a/aspen.vim
+++ b/aspen.vim
@@ -1,5 +1,7 @@
 " -*- vim -*-
-unlet b:current_syntax
+if exists("b:current_syntax")
+    unlet b:current_syntax
+endif
 syntax include @Python syntax/python.vim
 syntax region pythonCode start=// end=// contains=@Python
 


### PR DESCRIPTION
Without this check I get the following:

  Error detected while processing /Users/whit537/.vim/syntax/aspen.vim:  
  line    2:
  E108: No such variable: "b:current_syntax"
  Press ENTER or type command to continue
